### PR TITLE
feat: escape path and support 'src' parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,18 @@ $ curl https://adobeioruntime.net/api/v1/web/helix/default/embed/http://www.adob
 <div>
 ```
 
+While the above is simple to type, it is more safe to escape the url and optionally pass it as `src` query parameter:
+
+```bash
+curl https://adobeioruntime.net/api/v1/web/helix/default/embed/http%3A%2F%2Fwww.adobe.com
+```
+
+or
+
+```bash
+curl https://adobeioruntime.net/api/v1/web/helix/default/embed?src=http%3A%2F%2Fwww.adobe.com
+```
+
 ## Deployment
 
 The default deployment can be started with `npm run deploy`.

--- a/src/data-source.js
+++ b/src/data-source.js
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2020 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+const querystring = require('querystring');
+
+/**
+ * Analyses the params and extracts the data source, which is specified by a `src` param.
+ * For backward compatibility, the source can also be added as path, either escaped or unescaped.
+ *
+ * @param {string} params the openwhisk action params
+ * @return {URL} the extracted data source or null
+ */
+function dataSource(params) {
+  const { __ow_path: path = '', src = '' } = params;
+  if (!path) {
+    if (!src.startsWith('https://')) {
+      return null;
+    }
+    return new URL(params.src);
+  }
+
+  // expect the _ow_path to start with /https:// or /https%3a%2f%2f
+  if (path.startsWith('/https%3A%2F%2F')) {
+    return new URL(decodeURIComponent(path.substring(1)));
+  }
+  if (!path.startsWith('/https://')) {
+    return null;
+  }
+  const url = new URL(path.substring(1));
+
+  if (!params.__ow_query) {
+    // reconstruct __ow_query
+    Object.keys(params)
+      .filter((key) => !/^[A-Z]+_[A-Z]+/.test(key))
+      .filter((key) => key !== 'api')
+      .filter((key) => !/^__ow_/.test(key))
+      .forEach((key) => {
+        url.searchParams.append(key, params[key]);
+      });
+  } else {
+    // else add it to the url
+    Object.entries(querystring.parse(params.__ow_query)).forEach(([key, value]) => {
+      url.searchParams.append(key, value);
+    });
+  }
+  return url;
+}
+
+module.exports = dataSource;

--- a/src/embed.js
+++ b/src/embed.js
@@ -137,7 +137,7 @@ ${fromURL(url)}`,
  * @returns {string} class attribute for enclosing <div> tag
  */
 function getEmbedKind(url) {
-  const domains = new URL(url).hostname.split('.');
+  const domains = url.hostname.split('.');
   // remove first level domain
   domains.pop();
   const embedKind = [];

--- a/test/data-source.test.js
+++ b/test/data-source.test.js
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2020 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+/* eslint-env mocha */
+const assert = require('assert');
+const querystring = require('querystring');
+const dataSource = require('../src/data-source.js');
+
+describe('Data Source Tests', () => {
+  it('returns null for no path or src', () => {
+    assert.equal(dataSource({}), null);
+  });
+
+  it('rejects paths not starting with https://', () => {
+    assert.equal(dataSource({
+    }),
+    null);
+  });
+
+  it('rejects escaped paths not starting with https://', () => {
+    assert.equal(dataSource({
+      __ow_path: `/${querystring.escape('http://example.com')}`,
+    }),
+    null);
+  });
+
+  it('rejects src parameters not starting with https://', () => {
+    assert.equal(dataSource({
+      src: '/http://example.com',
+    }),
+    null);
+  });
+
+  it('returns data source for `src` parameter', () => {
+    assert.equal(dataSource({
+      src: 'https://adobeioruntime.net/api/v1/web/helix/helix-services/run-query@2.4.11/error500?a=1&b=2',
+    }),
+    'https://adobeioruntime.net/api/v1/web/helix/helix-services/run-query@2.4.11/error500?a=1&b=2');
+  });
+
+  it('returns data source for backward compat path parameter with no query', () => {
+    assert.equal(dataSource({
+      __ow_path: '/https://adobeioruntime.net/api/v1/web/helix/helix-services/run-query@2.4.11/error500?a=1&b=2',
+    }),
+    'https://adobeioruntime.net/api/v1/web/helix/helix-services/run-query@2.4.11/error500?a=1&b=2');
+  });
+
+  it('returns data source for backward compat path parameter with query', () => {
+    assert.equal(dataSource({
+      __ow_path: '/https://adobeioruntime.net/api/v1/web/helix/helix-services/run-query@2.4.11/error500',
+      __ow_query: 'a=1&b=2',
+    }),
+    'https://adobeioruntime.net/api/v1/web/helix/helix-services/run-query@2.4.11/error500?a=1&b=2');
+  });
+
+  it('returns data source for backward compat path parameter with query in params', () => {
+    assert.equal(dataSource({
+      __ow_path: '/https://adobeioruntime.net/api/v1/web/helix/helix-services/run-query@2.4.11/error500',
+      a: 1,
+      b: 2,
+    }),
+    'https://adobeioruntime.net/api/v1/web/helix/helix-services/run-query@2.4.11/error500?a=1&b=2');
+  });
+
+  it('returns data source for escaped path', () => {
+    assert.equal(dataSource({
+      __ow_path: `/${querystring.escape('https://adobeioruntime.net/api/v1/web/helix/helix-services/run-query@2.4.11/error500?a=1&b=2')}`,
+    }),
+    'https://adobeioruntime.net/api/v1/web/helix/helix-services/run-query@2.4.11/error500?a=1&b=2');
+  });
+});

--- a/test/embed.test.js
+++ b/test/embed.test.js
@@ -189,8 +189,8 @@ describe('Embed Tests', () => {
 
 describe('getEmbedKind tests', () => {
   it('getEmbedKind works with co.*', () => {
-    const jp = 'https://www.youtube.co.jp';
-    const spotify = 'https://www.open.spotify.com';
+    const jp = new URL('https://www.youtube.co.jp');
+    const spotify = new URL('https://www.open.spotify.com');
 
     const resultJp = getEmbedKind(jp);
     const resultSpotify = getEmbedKind(spotify);
@@ -201,7 +201,7 @@ describe('getEmbedKind tests', () => {
 
   it('getEmbedKind works with multiple domains', () => {
     const EXPECTED = 'embed-powerful embed-powerful-is embed-powerful-is-pipeline embed-powerful-is-pipeline-helix';
-    const longDomain = 'https://www.helix.pipeline.is.powerful.com';
+    const longDomain = new URL('https://www.helix.pipeline.is.powerful.com');
     const result = getEmbedKind(longDomain);
     assert.equal(result, EXPECTED);
   });


### PR DESCRIPTION
fixes #187

- encapsulates the extraction in own utility
- supports escaped `__ow_paths`
- supports `params.src` as data source
